### PR TITLE
Separating text printed from value used to color the areas

### DIFF
--- a/R/timeline.R
+++ b/R/timeline.R
@@ -10,6 +10,7 @@
 #' @param df data for time periods.
 #' @param events data for events (optional).
 #' @param label.col the column name in \code{df} to use for labeling.
+#' @param color.col the column name in \code{df} to use for coloring.
 #' @param group.col the column name in \code{df} to use for grouping.
 #' @param start.col the column name in \code{df} that specifies the start date.
 #' @param end.col the column name in \code{df} that specifies the end date.

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -57,6 +57,7 @@
 #' timeline(ww2, ww2.events, event.spots=2, event.label='', event.above=FALSE)
 timeline <- function(df, events,
 					 label.col = names(df)[1],
+					 color.col = names(df)[1],
 					 group.col = names(df)[2],
 					 start.col = names(df)[3],
 					 end.col = names(df)[4],
@@ -187,10 +188,11 @@ timeline <- function(df, events,
 	
 	p <- p +
 		geom_rect(data=df, aes_string(xmin=start.col, xmax=end.col,
-		          ymin='ymin', ymax='ymax', fill=label.col), alpha=.9, 
+		          ymin='ymin', ymax='ymax', fill=color.col), alpha=.9, 
 				  color=border.color, linetype=border.linetype) +
 		geom_text(data=df, aes_string(y='labelpos', x='labelpos.x', label=label.col),
 		          hjust=text.hjust, 
+		          angle= text.angle, 
 				  size=text.size, 
 				  color=text.color,
 				  alpha=text.alpha, 

--- a/demo/ww2.R
+++ b/demo/ww2.R
@@ -19,3 +19,18 @@ timeline(ww2, event.spots=2, event.label='', event.above=FALSE)
 #Modify the ggplot2 express after returing
 timeline(ww2, ww2.events, text.position='center', text.angle=45) +
 	theme(axis.text.y=element_text(angle=90, hjust=.5))
+
+# Flips coordinates and prints Text instead of Person
+timeline(ww2, #ww2.events,
+         color.col = "Person",
+         label.col = "Text",
+         text.position = "center",
+         text.size = 4,
+         text.angle = 0,
+         num.label.steps = 3,
+         event.spots = 4,
+         event.label.method = 1,
+         event.text.size = 4,
+         event.label = '',
+         event.line = TRUE,
+         event.above = TRUE) + coord_flip()

--- a/timeline.dev.r
+++ b/timeline.dev.r
@@ -53,6 +53,9 @@ ww2 <- as.data.frame(matrix(c(
 names(ww2) <- c('Person','Group','StartDate','EndDate')
 ww2$StartDate <- as.Date(ww2$StartDate)
 ww2$EndDate <- as.Date(ww2$EndDate)
+ww2$Text<-paste(gsub("[\\\n]"," ",ww2$Person),'\n',ww2$StartDate,'to',ww2$EndDate)
+# will generate string such as 'Franklin D. Roosevelt\n1933-03-04 to 1945-04-12'
+# does not always prints nice 
 
 ww2.events <- as.data.frame(matrix(c(
 	'Japan Invades Manchuria','1931-09-18','Axis',


### PR DESCRIPTION
The current version used the same column for printing text and coloring the areas.
This may not always be the case so a new parameter has been added to decouple both concepts.
The documentation on timeline.R has been updated.
An example has been added to ww2.R based on a new column added to the ww2 dataset
